### PR TITLE
Update README.md installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This is a React application demonstrating how to use the AWS IoT platform via MQ
 1. Clone the repository
 
 ```
-$ git clone git@github.com:awslabs/aws-iot-chat-example.git
+$ git clone https://github.com/aws-samples/aws-iot-chat-example.git
 ```
 
 2. Deploy the backend


### PR DESCRIPTION
`git clone git@github.com:awslabs/aws-iot-chat-example.git` results in:
```
Cloning into 'aws-iot-chat-example'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Replaced with:
`git clone https://github.com/aws-samples/aws-iot-chat-example.git`