### PR TITLE
setup.sh generates IoT endpoint with ATS certificate

### DIFF
--- a/client/scripts/setup.sh
+++ b/client/scripts/setup.sh
@@ -88,7 +88,7 @@ function generate_config() {
   success "Found Identity Pool Id"
 
   # IoT Endpoint
-  iot_endpoint=$(aws iot describe-endpoint | jq '.endpointAddress')
+  iot_endpoint=$(aws iot describe-endpoint --endpoint-type iot:Data-ATS | jq '.endpointAddress')
   iot_endpoint=${iot_endpoint//\"}
   jq --arg IOT_ENDPOINT $iot_endpoint '. + { AwsIotHost: $IOT_ENDPOINT }' config.json > temp.json \
     && mv temp.json config.json


### PR DESCRIPTION
*Issue #, if available:*
Issues #14 and #16 

*Description of changes:*
client/scripts/setup.sh now generates correts IotT Endpoint (`-ats`) with ATS certificate. App now works out-of-the-box again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
