### PR TITLE
Update attachPublicPublish.js

### DIFF
--- a/api/src/policy/attachPublicPublish.js
+++ b/api/src/policy/attachPublicPublish.js
@@ -47,17 +47,30 @@ export const main = async (event, context, callback) => {
 
   const policyDocument = generatePolicyDocumentTemplate(principal, accountArn);
 
-  try {
-    await iot.createPolicy(JSON.stringify(policyDocument), policyName);
-    await iot.attachPrincipalPolicy(policyName, principal);
-    callback(null, success({ status: true }));
-  } catch (e) {
-    if (e.statusCode === 409) {
-      // Policy already exists for this cognito identity
-      callback(null, success({ status: true }));
-    } else {
-      console.log(e);
-      callback(null, failure({ status: false, error: e }));
-    }
+try {
+  await iot.createPolicy(JSON.stringify(policyDocument), policyName);
+} catch (e) {
+  if (e.statusCode === 409) {
+    // Policy already exists
+    console.log("Policy already exists. Skipping policy creation.");
+  } else {
+    console.log(e);
+    callback(null, failure({ status: false, error: e }));
   }
+}
+
+try {
+  await iot.attachPrincipalPolicy(policyName, principal);
+  console.log(
+    "Successfully attached the policy: " +
+      policyName +
+      " IdentityId: " +
+      principal
+  );
+  callback(null, success({ status: true }));
+} catch (e) {
+  console.log(e);
+  callback(null, failure({ status: false, error: e }));
+}
+  
 };


### PR DESCRIPTION
*Issue #, if available:*
When we use the createPolicy and attachPrincipalPolicy in the same try block like in the example, we can attach a policy only the first time we created it.

*Description of changes:*
According to AttachPrincipalPolicy documentation, 409 status code is not valid. However, in CreatePolicy documentation, it has been noted as "The resource already exists."

When we use the createPolicy and attachPrincipalPolicy in the same try block like in the example, we can attach a policy only the first time we created it. That is why I think "Policy already exists for this cognito identity" is misleading.

https://docs.aws.amazon.com/iot/latest/apireference/API_AttachPrincipalPolicy.html
https://docs.aws.amazon.com/iot/latest/apireference/API_CreatePolicy.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.