### PR TITLE
Removed misleading error handling

### DIFF
--- a/api/src/policy/attachPublicSubscribe.js
+++ b/api/src/policy/attachPublicSubscribe.js
@@ -26,12 +26,7 @@ export const main = async (event, context, callback) => {
     await iot.attachPrincipalPolicy(POLICY_NAME, principal);
     callback(null, success({ status: true }));
   } catch (e) {
-    if (e.statusCode === 409) {
-      // Policy already exists for this cognito identity
-      callback(null, success({ status: true }));
-    } else {
       console.log(e);
       callback(null, failure({ status: false, error: e }));
-    }
   }
 };


### PR DESCRIPTION
*Description of changes:*

According to AttachPrincipalPolicy documentation, 409 status code is not valid. However, in CreatePolicy documentation, it has been noted as "The resource already exists". That is why I think "Policy already exists for this cognito identity" is misleading.

https://docs.aws.amazon.com/iot/latest/apireference/API_AttachPrincipalPolicy.html
https://docs.aws.amazon.com/iot/latest/apireference/API_CreatePolicy.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.