### PR TITLE
feature: allow user to use a custom AWS Profile instead of default

### DIFF
--- a/api/scripts/detach_policies.sh
+++ b/api/scripts/detach_policies.sh
@@ -3,6 +3,7 @@
 # To tear down the stack, we must detach principals from policies. This script will be run as a before:remove hook to prevent the following error
 # An error occurred: PublicSubscribePolicy - The policy cannot be deleted as the policy is attached to one or more principals (name=PublicSubscribePolicy).
 
+AWS_PROFILE_NAME=$1
 
 function fail() {
   tput setaf 1; echo "Failure: $*" && tput sgr0
@@ -50,7 +51,7 @@ function detach_policies() {
       continue
     fi
     info "Fetching list of targets for $policy"
-    targets=$(aws iot list-targets-for-policy --policy-name $policy | jq --raw-output '.targets | .[]')
+    targets=$(aws iot list-targets-for-policy --policy-name $policy --profile $AWS_PROFILE_NAME | jq --raw-output '.targets | .[]')
     success "Got list of targets for $policy"
 
     for full_target in $targets; do
@@ -58,12 +59,12 @@ function detach_policies() {
 
       info "Detaching $policy from $target"
 
-      aws iot detach-policy --policy-name $policy --target $target
+      aws iot detach-policy --policy-name $policy --target $target --profile $AWS_PROFILE_NAME
       success "Detached $policy from $target"
     done
 
     info "Deleting $policy"
-    aws iot delete-policy --policy-name $policy
+    aws iot delete-policy --policy-name $policy --profile $AWS_PROFILE_NAME
     success "Deleted $policy"
   done
 }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -9,13 +9,14 @@ custom:
   variables: ${file(./config.yml)}
   hooks:
     after:aws:deploy:finalize:cleanup:
-      - ./scripts/attachConfirmUserTrigger.sh
-      - ./../client/scripts/setup.sh
+      - ./scripts/attachConfirmUserTrigger.sh ${self:provider.profile}
+      - ./../client/scripts/setup.sh ${self:provider.profile}
     before:remove:remove:
       - ./scripts/detach_policies.sh
 
 provider:
   name: aws
+  profile: default
   runtime: nodejs8.10
   stage: prod
   region: ${opt:region, self:custom.variables.region}
@@ -31,7 +32,11 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-      Resource: { "Fn::Join" : ["",["arn:aws:dynamodb:",{"Ref":"AWS::Region"},":*:*"]] }
+      Resource:
+        {
+          "Fn::Join":
+            ["", ["arn:aws:dynamodb:", { "Ref": "AWS::Region" }, ":*:*"]],
+        }
     - Effect: Allow
       Action:
         - iot:AttachPrincipalPolicy
@@ -175,11 +180,11 @@ resources:
         PolicyDocument:
           Version: "2012-10-17"
           Statement:
-          - Effect: "Allow"
-            Action:
-              - "iot:Connect"
-            Resource:
-              - "*"
+            - Effect: "Allow"
+              Action:
+                - "iot:Connect"
+              Resource:
+                - "*"
 
     PublicSubscribePolicy:
       Type: "AWS::IoT::Policy"
@@ -188,10 +193,23 @@ resources:
         PolicyDocument:
           Version: "2012-10-17"
           Statement:
-          - Effect: "Allow"
-            Action:
-              - "iot:Subscribe"
-            Resource: { "Fn::Join" : ["",["arn:aws:iot:",{"Ref":"AWS::Region"},":",{"Ref":"AWS::AccountId"},":topicfilter/room/public/*"]] }
+            - Effect: "Allow"
+              Action:
+                - "iot:Subscribe"
+              Resource:
+                {
+                  "Fn::Join":
+                    [
+                      "",
+                      [
+                        "arn:aws:iot:",
+                        { "Ref": "AWS::Region" },
+                        ":",
+                        { "Ref": "AWS::AccountId" },
+                        ":topicfilter/room/public/*",
+                      ],
+                    ],
+                }
 
     PublicReceivePolicy:
       Type: "AWS::IoT::Policy"
@@ -200,10 +218,23 @@ resources:
         PolicyDocument:
           Version: "2012-10-17"
           Statement:
-          - Effect: "Allow"
-            Action:
-              - "iot:Receive"
-            Resource: { "Fn::Join" : ["",["arn:aws:iot:",{"Ref":"AWS::Region"},":",{"Ref":"AWS::AccountId"},":topic/room/public/*"]] }
+            - Effect: "Allow"
+              Action:
+                - "iot:Receive"
+              Resource:
+                {
+                  "Fn::Join":
+                    [
+                      "",
+                      [
+                        "arn:aws:iot:",
+                        { "Ref": "AWS::Region" },
+                        ":",
+                        { "Ref": "AWS::AccountId" },
+                        ":topic/room/public/*",
+                      ],
+                    ],
+                }
 
     UserPool:
       Type: "AWS::Cognito::UserPool"
@@ -263,12 +294,27 @@ resources:
         Policies:
           - PolicyName: iot-chat-invoke-api-gateway
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
                     - execute-api:Invoke
-                  Resource: { "Fn::Join" : ["", ["arn:aws:execute-api:",{"Ref":"AWS::Region"},":",{"Ref":"AWS::AccountId"},":",{"Ref":"ApiGatewayRestApi"},"/*"]] }
+                  Resource:
+                    {
+                      "Fn::Join":
+                        [
+                          "",
+                          [
+                            "arn:aws:execute-api:",
+                            { "Ref": "AWS::Region" },
+                            ":",
+                            { "Ref": "AWS::AccountId" },
+                            ":",
+                            { "Ref": "ApiGatewayRestApi" },
+                            "/*",
+                          ],
+                        ],
+                    }
 
     IdentityPoolRoleAttachment:
       Type: AWS::Cognito::IdentityPoolRoleAttachment


### PR DESCRIPTION
*Issue #, if available:*
#4 #6 #11 

*Description of changes:*
Now, a user can write in a AWS Profile name within api/serverless.yml
This will allow the user to specify which AWS Profile they would like.
Also, the current three helper scripts have been updated to reflect
this change as well (setup.sh, detach_policies.sh, attachConfirmUserTrigger.sh)
👍

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
