### PR TITLE
replaces all versions of nodejs to 10.x

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -17,7 +17,7 @@ custom:
 provider:
   name: aws
   profile: default
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   stage: prod
   region: ${opt:region, self:custom.variables.region}
 


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #29 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
