### PR TITLE
Update Serverless Framework URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This is the main chat page where the real-time messaging is displayed. You will 
 
 ### Backend
 
-To deploy the backend, this project uses the [Serverless Framework](https://serverless.com/framework/) which is backed by [AWS CloudFormation](https://aws.amazon.com/cloudformation/). In the `api/serverless.yml` file, functions, events, resources and services are defined which Serverless uses to deploy the appropriate Lambda functions, API Gateway services and additional CloudFormation resources.
+To deploy the backend, this project uses the [Serverless Framework](https://serverless.com/framework/docs/) which is backed by [AWS CloudFormation](https://aws.amazon.com/cloudformation/). In the `api/serverless.yml` file, functions, events, resources and services are defined which Serverless uses to deploy the appropriate Lambda functions, API Gateway services and additional CloudFormation resources.
 
 #### IoT Topics
 


### PR DESCRIPTION
*Issue #, if available:*
`None`

*Description of changes:*
The previous url pointed to a missing resource, '/framework', but later gets redirected to '/cli'. I find this tutorial really helpful and would like to keep at the best possible maintenance standards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
