### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -17,7 +17,7 @@ custom:
 provider:
   name: aws
   profile: default
-  runtime: nodejs10.x
+  runtime: nodejs14.x
   stage: prod
   region: ${opt:region, self:custom.variables.region}
 


### PR DESCRIPTION
CloudFormation templates in aws-iot-chat-example have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.