### PR TITLE
add node version instructions to avoid compatibility issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please note that this project has only been tested on macOS. Windows users may n
   * Ensure that the aws cli region is the same as what you define in `api/config.yml`
   * Please configure your `output` format to be `json`. [Instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-output.html)
 * [jq](https://stedolan.github.io/jq/) to process command-line JSON.
-* [npm](https://www.npmjs.com/get-npm) the node package manager
+* [npm](https://www.npmjs.com/get-npm) the node package manager (Please choose node version 14.*.* for best compatibility)
 
 1. Clone the repository
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added instructions for node version as per my testing the repo works fine with node version 14 but not working with node 16 or above, which caused me quite some time for debugging. Adding this instruction to avoid the same issue to others.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
