### PR TITLE
fix: remove clear text storage of credentials in sessionStorage

### DIFF
--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -81,10 +81,8 @@ export const handleSignOut = () => (
  * @param {string} token - Token from identity provider
  */
 const loginUserSuccess = (dispatch, user, awsCredentials, provider, token) => {
-  sessionStorage.setItem('awsCredentials', JSON.stringify(awsCredentials));
   sessionStorage.setItem('isLoggedIn', 'true');
   sessionStorage.setItem('provider', provider);
-  sessionStorage.setItem('providerToken', token);
   dispatch({ type: LOGIN_USER_SUCCESS, user });
   dispatch({ type: LOGGED_IN_STATUS_CHANGED, loggedIn: true });
   const identityId = Cognito.getIdentityId();

--- a/client/src/actions/iotActions.js
+++ b/client/src/actions/iotActions.js
@@ -48,7 +48,7 @@ export const acquirePublicPolicies = (connectCallback, closeCallback) => (
     }
     const identityId = Cognito.getIdentityId();
     dispatch({ type: IDENTITY_UPDATED, identityId });
-    const awsCredentials = JSON.parse(sessionStorage.getItem('awsCredentials'));
+    const awsCredentials = Cognito.getCurrentCredentials();
 
     IoT.initNewClient(awsCredentials);
     IoT.attachConnectHandler(connectCallback);

--- a/client/src/lib/aws-cognito.js
+++ b/client/src/lib/aws-cognito.js
@@ -275,3 +275,8 @@ export const register = (username, password, email) => (
     });
   })
 );
+
+export const getCurrentCredentials = () => {
+  const { accessKeyId, secretAccessKey, sessionToken } = AWS.config.credentials;
+  return { accessKeyId, secretAccessKey, sessionToken };
+};

--- a/client/src/lib/sigV4Client.js
+++ b/client/src/lib/sigV4Client.js
@@ -188,7 +188,11 @@ sigV4Client.newClient = function(config) {
     config.defaultContentType || "application/json";
 
   const invokeUrl = config.endpoint;
-  const endpoint = /(^https?:\/\/[^/]+)/g.exec(invokeUrl)[1];
+  const match = /(^https?:\/\/[^/]+)/g.exec(invokeUrl);
+  if (!match) {
+    throw new Error(`Invalid endpoint URL: ${invokeUrl}`);
+  }
+  const endpoint = match[1];
   const pathComponent = invokeUrl.substring(endpoint.length);
 
   awsSigV4Client.endpoint = endpoint;


### PR DESCRIPTION
## Summary
  
  Resolves code scanning alert #1 (js/clear-text-storage-of-sensitive-data).
  
  ### Problem
  `awsCredentials` (containing `accessKeyId`, `secretAccessKey`, `sessionToken`) and `providerToken` were stored as clear text
  in `sessionStorage`, making them accessible to any script running on the page (XSS risk).
  
  ### Fix
  - Removed `sessionStorage.setItem('awsCredentials', ...)` and `sessionStorage.setItem('providerToken', ...)`
  - IoT client now reads credentials directly from the AWS SDK's in-memory credential provider (`AWS.config.credentials`)
  - Added `getCurrentCredentials()` helper to aws-cognito lib
  - Also fixed null dereference in sigV4Client URL regex match